### PR TITLE
Remove the back-slashes to escape a slash

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,7 @@
   "minimumReleaseAge": "2 days",
   "renovate-config-presets": {
     "managerFilePatterns": [
-      "/(^|\\/).?(renovate(?:rc)?|default)(?:\\.json5?)?$/"
+      "/(^|/).?(renovate(?:rc)?|default)(?:\\.json5?)?$/"
     ]
   },
   "reviewers": ["5ouma"],


### PR DESCRIPTION
It's not needed to be escaped since just for matching.