### PR TITLE
Remove the Renovate strict flag quotes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
     hooks:
       - id: renovate-config-validator
         files: (^|/).?(renovate(?:rc)?|default|labels)(?:\.json5?)?$
-        args: ["--strict"]
+        args: [--strict]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.44.0


### PR DESCRIPTION
YAML doesn't force strings to be quoted.