### PR TITLE
Install Deno dependencies at the end of steps

### DIFF
--- a/setup-deno-with-cache/action.yml
+++ b/setup-deno-with-cache/action.yml
@@ -15,3 +15,8 @@ runs:
           ~/.deno
           ~/.cache/deno
         key: ${{ runner.os }}-deno-${{ hashFiles('./deno.lock') }}
+
+    - name: 📦 Install Dependencies
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      run: deno install --frozen
+      shell: bash


### PR DESCRIPTION
It's nice to be able to split the setup section and process section.