### PR TITLE
Use pre-commit.ci lite instead of GitHub Actions bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ jobs:
 ```
 
 > [!IMPORTANT]
-> You need to install [autofix.ci](https://autofix.ci) to commit the changes.
+> You need to install [pre-commit.ci lite] to commit the changes.
+
+[pre-commit.ci lite]: https://pre-commit.ci/lite
 
 ## 🏷️ Labeler
 

--- a/update-deno-lock-file/action.yml
+++ b/update-deno-lock-file/action.yml
@@ -23,8 +23,8 @@ runs:
       run: echo "files=$(git ls-files -mo --exclude-standard)" | tee -a "$GITHUB_OUTPUT"
       shell: bash
 
-    - name: 📝 Commit and Push Changes
+    - name: 🚸 Run pre-commit-ci-lite
       if: ${{ steps.check.outputs.files != '' }}
-      uses: autofix-ci/action@2891949f3779a1cafafae1523058501de3d4e944 # v1.3.1
+      uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
       with:
-        commit-message: "chore(deps): Update deno.lock"
+        msg: "chore(deps): Update deno.lock"


### PR DESCRIPTION
It allows the `pull_request` event workflows since it's an app.