### PR TITLE
Git commiter must be set on checkout

### DIFF
--- a/.github/ghalint.yml
+++ b/.github/ghalint.yml
@@ -1,0 +1,4 @@
+excludes:
+  - policy_name: checkout_persist_credentials_should_be_false
+    workflow_file_path: .github/workflows/release.yml
+    job_name: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,6 @@ jobs:
     timeout-minutes: 1
 
     steps:
-      - name: 🚚 Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-
       - name: 💳 Create GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
@@ -27,6 +22,12 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+
+      - name: 🚚 Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
 
       - name: 🔖 Release a new version
         id: tagpr


### PR DESCRIPTION
It's needed to store Git credentials even after checking out the repository.