### PR TITLE
Add job names even if it's the only one

### DIFF
--- a/.github/workflows/gist-update.yml
+++ b/.github/workflows/gist-update.yml
@@ -8,7 +8,8 @@ on:
 permissions: {}
 
 jobs:
-  Update:
+  update:
+    name: ⬆️ Update OPML in Gist
     runs-on: Ubuntu-Latest
     timeout-minutes: 1
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 jobs:
   labeler:
+    name: 🏷️ Labeler
     permissions:
       pull-requests: write
     runs-on: Ubuntu-Latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   pre-commit:
+    name: 🚸 pre-commit
     runs-on: Ubuntu-Latest
     timeout-minutes: 3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   release:
+    name: 🚀 Release
     runs-on: Ubuntu-Latest
     timeout-minutes: 1
 


### PR DESCRIPTION
Zizmor requires them for pedantic auditions.