### PR TITLE
Add `--no-config` flag to zizmor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
     rev: v1.13.0
     hooks:
       - id: zizmor
+        args: [--no-config]
 
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 41.127.2


### PR DESCRIPTION
It misses the root action.yml as a config file.