### PR TITLE
Avoid using the `commands` variable name

### DIFF
--- a/pre-commit/scripts/upload-git-commit-notion
+++ b/pre-commit/scripts/upload-git-commit-notion
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-commands=(op jq)
-for cmd in "${commands[@]}"; do
+cmds=(op jq)
+for cmd in "${cmds[@]}"; do
   (type "$cmd" &>/dev/null) || exit 0
 done
 


### PR DESCRIPTION
It's been used by the system.