### PR TITLE
Return only PR numbers to label past PR

### DIFF
--- a/label-past-pr/action.yml
+++ b/label-past-pr/action.yml
@@ -31,7 +31,7 @@ runs:
             pr.head.ref === branch &&
             pr.merged_at &&
             !pr.labels.some((existingLabel) => existingLabel.name === label)
-          );
+          ).map((pr) => pr.number);
       env:
         author: ${{ github.event.pull_request.user.login }}
         branch: ${{ github.head_ref }}
@@ -49,7 +49,7 @@ runs:
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: pr.number,
+              issue_number: pr,
               labels: [label],
             });
           }


### PR DESCRIPTION
Avoid a result length that becomes too long.