### PR TITLE
Set up Node.js before running Bun

### DIFF
--- a/setup-bun-with-cache/action.yml
+++ b/setup-bun-with-cache/action.yml
@@ -15,6 +15,11 @@ runs:
         path: ./node_modules
         key: bun-${{ runner.os }}-${{ hashFiles('./bun.lock') }}
 
+    - name: 🐢 Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 25.9.0
+
     - name: 📦 Install dependencies
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: bun install --frozen-lockfile


### PR DESCRIPTION
Bun uses Node.js as a runtime by default.