### PR TITLE
Don't set up Go if all hooks are restored

### DIFF
--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -25,11 +25,6 @@ runs:
       env:
         PREK_VERSION: v0.3.11
 
-    - name: 🐹 Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version: 1.26.2
-
     - name: "#️⃣ Download pre-commit hooks"
       id: hooks
       if: ${{ inputs.config == '.pre-commit-config.yaml' && hashFiles(inputs.config) == '' }}
@@ -41,7 +36,21 @@ runs:
         ACTION_REPOSITORY: ${{ github.action_repository }}
         ACTION_REF: ${{ github.action_ref }}
 
+    - name: 🫙 Exact cache pre-commit dependencies
+      id: cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/prek
+        key: pre-commit-${{ runner.os }}-${{ hashFiles(inputs.config) }}
+
+    - name: 🐹 Set up Go
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: 1.26.2
+
     - name: 🫙 Cache pre-commit dependencies
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/prek


### PR DESCRIPTION
It's only needed to install new Go packages.