### PR TITLE
Make Renovate to treat as repo-wide config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
         language: bun
         language_version: default
         files: (^|/).?(renovate(?:rc)?|default|labels)(?:\.json5?)?$
-        args: [--strict]
+        args: [--strict, --no-global]
 
   - repo: https://github.com/rvben/rumdl-pre-commit
     rev: 5db5f54bd3645bf9fecd8a56c052b9208b2d478d # frozen: v0.1.87


### PR DESCRIPTION
The renovate-config-validator treats config as global by default.