### PR TITLE
Start running Merge Gatekeeper when each workflow finishes

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -1,0 +1,25 @@
+name: 🛡️ Merge Gatekeeper
+
+on:
+  check_suite:
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  merge-gatekeeper:
+    name: 🛡️ Merge Gatekeeper
+    permissions:
+      checks: read
+      statuses: read
+    runs-on: Ubuntu-Latest
+    if: ${{ toJSON(github.event.check_suite.pull_requests) != '[]' }}
+    timeout-minutes: 10
+
+    steps:
+      - name: 🛡️ Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          self: 🛡️ Merge Gatekeeper
+          ignored: CodeRabbit


### PR DESCRIPTION
Reduce the running time of Gatekeeper.