### PR TITLE
Set release persist-credential false

### DIFF
--- a/.github/ghalint.yml
+++ b/.github/ghalint.yml
@@ -1,4 +1,0 @@
-excludes:
-  - policy_name: checkout_persist_credentials_should_be_false
-    workflow_file_path: .github/workflows/release.yml
-    job_name: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,10 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: true
+          persist-credentials: false
+
+      - name: 🔐 Set up Credential Helper
+        run: gh auth setup-git
 
       - name: 🔖 Release a new version
         id: tagpr
@@ -39,4 +42,5 @@ jobs:
         with:
           config: .github/tagpr.ini
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Set the GitHub CLI as a Git credential helper to operate.