### PR TITLE
Make Renovate minimum release age to 5 days

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,7 @@
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "dependencyDashboard": false,
-  "minimumReleaseAge": "2 days",
+  "minimumReleaseAge": "5 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "reviewers": ["5ouma"],
   "packageRules": [


### PR DESCRIPTION
Slower dependency update to prevent malicious versions.