### PR TITLE
Don't pass empty array on label

### DIFF
--- a/label-past-pr/action.yml
+++ b/label-past-pr/action.yml
@@ -46,7 +46,7 @@ runs:
       with:
         script: |
           const { label } = process.env;
-          const prs = JSON.parse(process.env.prs ?? "[]");
+          const prs = JSON.parse(process.env.prs);
 
           for (const pr of prs) {
             await github.rest.issues.addLabels({


### PR DESCRIPTION
Since it's JavaScript, there's no need to fall back on falsy.