### PR TITLE
Loosen timeout minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     defaults:
       run:
         working-directory: pre-commit/hooks
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository
@@ -80,7 +80,7 @@ jobs:
     defaults:
       run:
         working-directory: pre-commit/hooks
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository
@@ -104,7 +104,7 @@ jobs:
     defaults:
       run:
         working-directory: pre-commit/hooks
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository


### PR DESCRIPTION
One minute is too tight to finish workflows completely.